### PR TITLE
Add 'timeAxisMode' parameter

### DIFF
--- a/gantt/appserver/static/components/gantt/gantt.js
+++ b/gantt/appserver/static/components/gantt/gantt.js
@@ -247,6 +247,7 @@ define(function(require, exports, module) {
             var compact       = (this.settings.get('compact')    === 'true');
             var categoryLabel = this.settings.get('categoryLabel');
             var seriesLabel   = this.settings.get('seriesLabel');
+            var timeAxisMode  = this.settings.get('timeAxisMode');
 
 
             if (compact) {
@@ -288,9 +289,27 @@ define(function(require, exports, module) {
 
 
             // Now make the X axis
-            var x = d3.time.scale()
-                .domain([new Date(this.manager.search.attributes.data.earliestTime),
-                         new Date(this.manager.search.attributes.data.latestTime)])
+            var timeRange;
+            if (timeAxisMode === 'DATA_RANGE') {
+                var earliestStart;
+                var latestEnd;
+                var numPoints = data.length;
+                for (var i = 0; i < numPoints; i++) {
+                    var dataPoint = data[i];
+                    if (earliestStart == null || dataPoint.startTime.getTime() < earliestStart) {
+                        earliestStart = dataPoint.startTime.getTime();
+                    }
+                    if (latestEnd == null || dataPoint.endTime.getTime() > latestEnd) {
+                        latestEnd = dataPoint.endTime.getTime();
+                    }
+                }
+                timeRange = [new Date(earliestStart), new Date(latestEnd)];
+            }
+            else {  // SEARCH_RANGE
+                timeRange = [new Date(this.manager.search.attributes.data.earliestTime),
+                             new Date(this.manager.search.attributes.data.latestTime)];
+            }
+            var x = d3.time.scale().domain(timeRange)
                 .range([0, width - yAxisBBox.width - margin.left]);
 
             var xAxis = viz.svg.append("g")
@@ -679,3 +698,4 @@ define(function(require, exports, module) {
 
     return GanttChart;
 });
+

--- a/gantt/appserver/static/docs/demo.html
+++ b/gantt/appserver/static/docs/demo.html
@@ -18,6 +18,7 @@ according to the series (users, in the previous example).
     <li><code>showLegend</code>: if 'true', displays the series under the chart as a legend. Default is 'true'.</li>
     <li><code>compact</code>: if 'true', makes the bars thinner in order to fit more of them. This is particularly useful when there are many concurrent tasks or categories. Default is 'false'.</li>
     <li><code>extrasField</code>: field that represents any extra information you want displayed in the tooltip. This field can be standard text or a JSON object (such as <code>eval extras="{\"Source Type\": \""+sourcetype+"\", \"Host\": \""+host+"\"}"</code>, note the use of double quotes, which must be properly escaped if defined inside the .xml). The keys of the JSON object will be the labels of the values in the tooltip. You can include HTML in the field, but please use this wisely.</li>
+    <li><code>timeAxisMode</code>: if 'DATA_RANGE', the x-axis time range is only from the earliest start time in the data to the latest end time in the data.  Default is 'SEARCH_RANGE', where the x-axis time range covers from the 'earliest_time' in the search criteria to the 'latest_time' in the search criteria.</li>
 </ul></p>
 
 <p>Note that any two of <code>startField</code>, <code>endField</code> or <code>durationField</code> 


### PR DESCRIPTION
This fixes Issue #3 by adding a parameter that enables
compressing the time axis range to be from the start of the earliest
event to the end of the latest event in the search results.
