### PR TITLE
Add sortCategories boolean parameter

### DIFF
--- a/gantt/appserver/static/components/gantt/gantt.js
+++ b/gantt/appserver/static/components/gantt/gantt.js
@@ -243,11 +243,12 @@ define(function(require, exports, module) {
         updateView: function(viz, data) {
             var that = this;
 
-            var showLegend    = (this.settings.get('showLegend') === 'true');
-            var compact       = (this.settings.get('compact')    === 'true');
-            var categoryLabel = this.settings.get('categoryLabel');
-            var seriesLabel   = this.settings.get('seriesLabel');
-            var timeAxisMode  = this.settings.get('timeAxisMode');
+            var showLegend     = (this.settings.get('showLegend') === 'true');
+            var compact        = (this.settings.get('compact')    === 'true');
+            var categoryLabel  = this.settings.get('categoryLabel');
+            var seriesLabel    = this.settings.get('seriesLabel');
+            var timeAxisMode   = this.settings.get('timeAxisMode');
+            var sortCategories = (this.settings.get('sortCategories') !== 'false'); // default to 'true'
 
 
             if (compact) {
@@ -273,7 +274,11 @@ define(function(require, exports, module) {
             if (this.categorySeed) {
                 seed = this.categorySeed;
             }
-            var categories = _(_(data).pluck('category').concat(seed)).uniq().sort();
+            var categories = _(_(data).pluck('category').concat(seed)).uniq()
+            if (sortCategories) {
+                categories = categories.sort();
+            }
+
             var series     = _(_(data).pluck('series')).uniq().sort();
 
             // Prepare the color scale for the series

--- a/gantt/appserver/static/docs/demo.html
+++ b/gantt/appserver/static/docs/demo.html
@@ -19,6 +19,7 @@ according to the series (users, in the previous example).
     <li><code>compact</code>: if 'true', makes the bars thinner in order to fit more of them. This is particularly useful when there are many concurrent tasks or categories. Default is 'false'.</li>
     <li><code>extrasField</code>: field that represents any extra information you want displayed in the tooltip. This field can be standard text or a JSON object (such as <code>eval extras="{\"Source Type\": \""+sourcetype+"\", \"Host\": \""+host+"\"}"</code>, note the use of double quotes, which must be properly escaped if defined inside the .xml). The keys of the JSON object will be the labels of the values in the tooltip. You can include HTML in the field, but please use this wisely.</li>
     <li><code>timeAxisMode</code>: if 'DATA_RANGE', the x-axis time range is only from the earliest start time in the data to the latest end time in the data.  Default is 'SEARCH_RANGE', where the x-axis time range covers from the 'earliest_time' in the search criteria to the 'latest_time' in the search criteria.</li>
+    <li><code>sortCategories</code>: if 'true', categories are sorted by category label.  If 'false', categories are listed in the order they appear in the data returned from the search.  Default is 'true'.</li>
 </ul></p>
 
 <p>Note that any two of <code>startField</code>, <code>endField</code> or <code>durationField</code> 


### PR DESCRIPTION
This commit fixes Issue #5 by adding a 'sortCategories' boolean
parameter.  The default of 'true' maintains current functionality.  If
'false', the categories are ordered as they occur in the data.   Users
can apply a sort to their search to gain the desired category ordering.
