### PR TITLE
Update gantt.js for tooltip date format

### DIFF
--- a/gantt/appserver/static/components/gantt/gantt.js
+++ b/gantt/appserver/static/components/gantt/gantt.js
@@ -763,10 +763,10 @@ define(function(require, exports, module) {
     }
 
     function durationStr(t) {
+        var days    = Math.floor(t / 86400);
+        var hours   = Math.floor(t / 3600)  % 24;
+        var minutes = Math.floor(t / 60)    % 60;
 
-        var days    = parseInt(t / 86400);
-        var hours   = parseInt(t / 3600)  % 24;
-        var minutes = parseInt(t / 60)    % 60;
         var seconds = t % 60;
 
         var s = seconds.toFixed(3).replace(/0+$/, '').split('.');


### PR DESCRIPTION
Used Math.floor instead of parseInt when displaying date on tooltip, t / int is already a number, we just need to floor it as parInt is incorrect when the result is a tiny number such as parseInt(1.21312e-8) = 1 which is undesired"
[tooltipDateFix 830fa9f] Used Math.floor instead of parseInt when displaying date on tooltip, t / int is already a number, we just need to floor it as parInt is incorrect when the result is a tiny number such as parseInt(1.21312e-8) = 1 which is undesired
